### PR TITLE
Add scrolling headers to sources table.

### DIFF
--- a/app/assets/stylesheets/sources.scss
+++ b/app/assets/stylesheets/sources.scss
@@ -1,3 +1,20 @@
 // Place all the styles related to the sources controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+/* Override table header. */
+.floatingheader thead {
+    position: sticky;
+    top: 0;
+    background-color: white;
+    border-bottom: 1px solid dimgray;
+}
+
+/* Override table border trick
+   Replace with something else instead. */
+table.floatingheader {
+    border-collapse: separate;
+}
+table.floatingheader > tbody > tr:first-of-type > td {
+    border-top: none;
+}

--- a/app/views/sources/index.html.erb
+++ b/app/views/sources/index.html.erb
@@ -46,7 +46,7 @@
   </div>
 </div><!-- /.row -->
 
-<table class="table">
+<table class="table floatingheader">
   <thead>
     <tr>
       <th>Source <span class="badge"><%= @sources.size %></span></th>


### PR DESCRIPTION
This commit adds scrolling headers to the table.
It uses position: sticky, which recently started to work in chrome.
Also works in Safari (Webkit) and Firefox (Gecko).
In unsupported browsers (Edge) it falls back to no scrolling headers.