### PR TITLE
Add view PDF button.

### DIFF
--- a/app/views/sources/show/_header_section.html.erb
+++ b/app/views/sources/show/_header_section.html.erb
@@ -31,6 +31,13 @@
             class: 'btn btn-info' %>
     <% end %>
 
+    <% if @source.document.present? %>
+      <%= link_to raw("View PDF #{glyphicon 'new-window'}"),
+            url_for(format: :pdf),
+            class: 'btn btn-info',
+            target: '_blank' %>
+    <% end %>
+
     <% if @source.url.present? %>
       <%= link_to raw("Original Webpage #{glyphicon 'new-window'}"),
             @source.url,


### PR DESCRIPTION
Opens a new tab for the source page URL, with the PDF format and without
the download parameter. This way the content disposition is set to
inline and the PDF is displayed in the browser.

Resolves issue #21.